### PR TITLE
singleton-pattern

### DIFF
--- a/src/study2/designpattern/Singleton.java
+++ b/src/study2/designpattern/Singleton.java
@@ -1,0 +1,12 @@
+package study2.designpattern;
+
+public class Singleton {
+
+	private static final Singleton INSTANCE = new Singleton();
+	
+	private Singleton() {} // 생성자 호출을 통해 객체 생성되는 것을 private 접근 제한으로 막음
+	
+	public static Singleton getInstance() {
+		return INSTANCE; // 대신 클래스에서 생성한 객체를 getInstance 메소드 호출을 통해 객체를 얻어옴
+	}
+}

--- a/src/study2/designpattern/SingletonTest.java
+++ b/src/study2/designpattern/SingletonTest.java
@@ -1,0 +1,20 @@
+package study2.designpattern;
+
+public class SingletonTest {
+	public static void main(String[] args) {
+		
+//		Singleton a = new Singleton(); 생성자의 접근 제한을 private 로 지정했기 때문에, 생성자 호출 불가
+		
+		Singleton b = Singleton.getInstance(); // 생성자 대신 getInstance 메소드 호출을 통해 객체를 생성
+		Singleton c = Singleton.getInstance();
+		
+		System.out.println(b.hashCode());
+		System.out.println(c.hashCode()); // 둘 다 같은 객체인 것을 확인할 수 있다.
+		
+		if(b == c) {
+			System.out.println("This is a Singleton");
+		} else {
+			System.out.println("This is not a Singleton");
+		}
+	}
+}


### PR DESCRIPTION
싱글톤 패턴을 구현 해보았다.

싱글톤 패턴은 하나의 클래스에 하나의 인스턴스를 가지고 있어,
이 인스턴스로 로직을 구현하거나 데이터베이스 연결 모듈에 자주 사용된다.

단점으로는, 단위 테스트하기 어렵다는 점이 있다.
단위 테스트는 독립적으로 테스트 가능해야 하며 어느 순서로 실행해도 테스트가 가능해야 하는데
싱글톤 패턴으로 구현하면 각각의 단위 테스트에 독립된 객체를 호출하기가 어렵다.

이때는 의존성 주입을 통해 직접 객체를 생성하는 대신, 간접적으로 객체를 생성하여 객체간의 결합도를 낮출 수 있다.
