### PR TITLE
람다식 예제

### DIFF
--- a/src/study2/lamda/MyFunctionalInterface.java
+++ b/src/study2/lamda/MyFunctionalInterface.java
@@ -1,0 +1,10 @@
+package study2.lamda;
+
+@FunctionalInterface
+public interface MyFunctionalInterface {
+
+	// 자바에서는 메소드를 단독으로 선언할 수 없다.
+	// 람다식은 메소드를 가진 객체를 생성해 낸다.
+	
+	public void method();
+}

--- a/src/study2/lamda/MyFunctionalInterface2.java
+++ b/src/study2/lamda/MyFunctionalInterface2.java
@@ -1,0 +1,6 @@
+package study2.lamda;
+
+public interface MyFunctionalInterface2 {
+
+	public void method(int x);
+}

--- a/src/study2/lamda/MyFunctionalInterface3.java
+++ b/src/study2/lamda/MyFunctionalInterface3.java
@@ -1,0 +1,8 @@
+package study2.lamda;
+
+@FunctionalInterface
+public interface MyFunctionalInterface3 {
+
+	public int method(int x, int y);
+	
+}

--- a/src/study2/lamda/MyFunctionalInterfaceExample.java
+++ b/src/study2/lamda/MyFunctionalInterfaceExample.java
@@ -1,0 +1,29 @@
+package study2.lamda;
+
+public class MyFunctionalInterfaceExample {
+	public static void main(String[] args) {
+		
+		// 람다식은 인터페이스 변수에 대입된다.
+		// 인터페이스는 직접 객체를 생성할 수 없으므로 구현 클래스를 필요로 한다.
+		// 즉, 람다식은 인터페이스 변수에 대입되어 익명 구현 클래스를 생성하고 객체화 한다.
+		
+		// fi : 람다식의 타겟 타입
+		// 람다식은 하나의 추상 메소드를 정의하므로, 모든 인터페이스가 람다식의 타겟 타입이 될 수는 없다.
+		
+		MyFunctionalInterface fi = () -> {
+			String str = "method call1";
+			System.out.println(str);
+		};
+		
+		fi.method();
+		
+		fi = () -> { System.out.println("method call2"); };
+		
+		fi.method();
+		
+		// 실행문이 하나라면, 중괄호를 생략할 수 있다.
+		fi = () -> System.out.println("method call3");
+		
+		fi.method();
+	}
+}

--- a/src/study2/lamda/MyFunctionalInterfaceExample2.java
+++ b/src/study2/lamda/MyFunctionalInterfaceExample2.java
@@ -1,0 +1,24 @@
+package study2.lamda;
+
+public class MyFunctionalInterfaceExample2 {
+	public static void main(String[] args) {
+		
+		MyFunctionalInterface2 fi = (x) -> {
+			int result = x * 5;
+			System.out.println(result);
+		};
+		
+		// 매개값으로 5를 주면, 람다식의 x 변수에 대입되어 사용된다.
+		fi.method(5);
+		
+		fi = (x) -> {
+			System.out.println(x * 5);
+		};
+		
+		fi.method(5);
+		
+		fi = (x) -> System.out.println(x * 5);
+		
+		fi.method(5);
+	}
+}

--- a/src/study2/lamda/MyFunctionalInterfaceExample3.java
+++ b/src/study2/lamda/MyFunctionalInterfaceExample3.java
@@ -1,0 +1,39 @@
+package study2.lamda;
+
+public class MyFunctionalInterfaceExample3 {
+	public static void main(String[] args) {
+		
+		
+		MyFunctionalInterface3 fi = (x, y) -> {
+			int result = x * y;
+			return result;
+		};
+		
+		int answer = fi.method(7, 7);
+		System.out.println(answer);
+		
+		fi = (x, y) -> {
+			return x * y;
+		};
+		
+		int answer2 = fi.method(7, 8);
+		System.out.println(answer2);
+		
+		// 리턴문만 있을 경우 중괄호와 return문 생략이 가능하다.
+		
+		fi = (x, y) -> x * y;
+		
+		int answer3 = fi.method(7, 9);
+		System.out.println(answer3);
+		
+		// 리턴 타입이 같은 다른 메소드를 호출할 수도 있다.
+		fi = (x, y) -> sum(x, y);
+		
+		int answer4 = fi.method(7, 9);
+		System.out.println(answer4);
+	}
+
+	public static int sum(int x, int y) {
+		return x + y;
+	}
+}


### PR DESCRIPTION
람다식 예제를 작성해보았다.

람다식이란, 자바에서 함수지향 프로그래밍을 할 수 있도록 한다.

장점
+ 자바 코드가 간결해진다.
+ 컬렉션의 요소를 필터링하거나 매핑해서 원하는 결과를 쉽게 집계할 수 있다.

람다식은 익명 구현 객체를 생성한다.
자바에서는 메소드를 단독으로 선언할 수 없으므로 하나의 추상 메소드를 가진 인터페이스를 선언하고
인터페이스는 객체를 생성할 수 없으므로 구현 클래스가 필요한데, 람다식은 익명 구현 클래스를 생성하고 객체화한다.

즉, 인터페이스 변수에 람다식을 대입하여 객체를 생성해 낸다.
이때, 람다식이 대입되는 인터페이스 변수를 람다식의 '타겟 타입'이라고 한다.
모든 인터페이스가 람다식의 타겟 타입이 될 수는 없으며, 하나의 추상 클래스만을 가진 인터페이스만 람다식의 타겟 타입이 될 수 있다.

